### PR TITLE
Miracl dataset support

### DIFF
--- a/src/tevatron/datasets/dataset.py
+++ b/src/tevatron/datasets/dataset.py
@@ -23,7 +23,7 @@ class HFTrainDataset:
             data_files = {data_args.dataset_split: data_files}
         self.dataset = load_dataset(data_args.dataset_name,
                                     data_args.dataset_language,
-                                    data_files=data_files, cache_dir=cache_dir)[data_args.dataset_split]
+                                    data_files=data_files, cache_dir=cache_dir, use_auth_token=True)[data_args.dataset_split]
         self.preprocessor = PROCESSOR_INFO[data_args.dataset_name][0] if data_args.dataset_name in PROCESSOR_INFO\
             else DEFAULT_PROCESSORS[0]
         self.tokenizer = tokenizer
@@ -53,7 +53,7 @@ class HFQueryDataset:
             data_files = {data_args.dataset_split: data_files}
         self.dataset = load_dataset(data_args.dataset_name,
                                     data_args.dataset_language,
-                                    data_files=data_files, cache_dir=cache_dir)[data_args.dataset_split]
+                                    data_files=data_files, cache_dir=cache_dir, use_auth_token=True)[data_args.dataset_split]
         self.preprocessor = PROCESSOR_INFO[data_args.dataset_name][1] if data_args.dataset_name in PROCESSOR_INFO \
             else DEFAULT_PROCESSORS[1]
         self.tokenizer = tokenizer
@@ -80,7 +80,7 @@ class HFCorpusDataset:
             data_files = {data_args.dataset_split: data_files}
         self.dataset = load_dataset(data_args.dataset_name,
                                     data_args.dataset_language,
-                                    data_files=data_files, cache_dir=cache_dir)[data_args.dataset_split]
+                                    data_files=data_files, cache_dir=cache_dir, use_auth_token=True)[data_args.dataset_split]
         script_prefix = data_args.dataset_name
         if script_prefix.endswith('-corpus'):
             script_prefix = script_prefix[:-7]


### PR DESCRIPTION
Trying to use miracl/miracl datasets in tevatron generates this error:
```
FileNotFoundError: Dataset 'miracl/miracl' doesn't exist on the Hub. 
If the repo is private, make sure you are authenticated with `use_auth_token=True` after logging in with `huggingface-cli login`.
```
We can fix this by adding a requirement `use_auth_token=True` whenever we load a dataset from huggingface.