### PR TITLE
use self-contained dataset, add pyserini example

### DIFF
--- a/examples/splade/train_splade.py
+++ b/examples/splade/train_splade.py
@@ -28,7 +28,7 @@ class SpladeTrainer(TevatronTrainer):
     def __init__(self, *args, **kwargs):
         super(SpladeTrainer, self).__init__(*args, **kwargs)
         if self.args.negatives_x_device:    
-            self.world_size = torch.dist.get_world_size()
+            self.world_size = torch.distributed.get_world_size()
 
     @staticmethod
     def _flops(inputs):


### PR DESCRIPTION
Change SPLADE encoding config to self-contained datasets.

Add pyserini retrieval example and MRR@10 result.