### PR TITLE
changes within Repllama training and data script

### DIFF
--- a/examples/repllama/repllama.py
+++ b/examples/repllama/repllama.py
@@ -4,26 +4,24 @@ from torch import Tensor
 from transformers import LlamaModel, PreTrainedModel
 import logging
 from peft import LoraConfig, get_peft_model, PeftModel, TaskType
-from tevatron.modeling.encoder import EncoderModel
+from tevatron.retriever.modeling.encoder import EncoderModel
 
 logger = logging.getLogger(__name__)
 
 
 class RepLLaMA(EncoderModel):
     def __init__(self,
-                 lm_q: PreTrainedModel,
-                 lm_p: PreTrainedModel,
-                 pooler: nn.Module = None,
-                 untie_encoder: bool = False,
-                 negatives_x_device: bool = False
-                 ):
-        super().__init__(lm_q, lm_p, pooler, untie_encoder, negatives_x_device)
-        self.config = lm_q.config
+                 encoder: PreTrainedModel,
+                 pooling: str = 'cls',
+                 normalize: bool = False):
+        super().__init__(encoder, pooling, normalize)
+        self.config = encoder.config
+        self.encoder = encoder
 
     def encode_passage(self, psg):
         if psg is None:
             return None
-        psg_out = self.lm_p(**psg, output_hidden_states=True)
+        psg_out = self.encoder(**psg, output_hidden_states=True)
         p_hidden = psg_out.hidden_states[-1]
         attention_mask = psg['attention_mask']
         # p_reps is the last token representation that is not padding
@@ -36,7 +34,7 @@ class RepLLaMA(EncoderModel):
     def encode_query(self, qry):
         if qry is None:
             return None
-        qry_out = self.lm_q(**qry, output_hidden_states=True)
+        qry_out = self.encoder(**qry, output_hidden_states=True)
         q_hidden = qry_out.hidden_states[-1]
         attention_mask = qry['attention_mask']
         # q_reps is the last token representation that is not padding
@@ -51,7 +49,7 @@ class RepLLaMA(EncoderModel):
         return torch.matmul(q_reps, p_reps.transpose(0, 1)) / 0.01
     
     def gradient_checkpointing_enable(self):
-        self.lm_q.base_model.gradient_checkpointing_enable()
+        self.encoder.base_model.gradient_checkpointing_enable()
 
     
     @staticmethod
@@ -78,22 +76,25 @@ class RepLLaMA(EncoderModel):
         if base_model.config.pad_token_id is None:
             base_model.config.pad_token_id = 0
 
-        peft_config = LoraConfig(
-            base_model_name_or_path=model_args.model_name_or_path,
-            task_type=TaskType.FEATURE_EXTRACTION,
-            r=32,
-            lora_alpha=64,
-            lora_dropout=0.1,
-            target_modules=["q_proj", "v_proj", "o_proj", "down_proj", "up_proj", "gate_proj"],
-            inference_mode=False
-        )
+        if model_args.lora:
+            peft_config = LoraConfig(
+                base_model_name_or_path=model_args.model_name_or_path,
+                task_type=TaskType.FEATURE_EXTRACTION,
+                r=model_args.lora_r,
+                lora_alpha=model_args.lora_alpha,
+                lora_dropout=model_args.lora_dropout,
+                target_modules=model_args.lora_target_modules.split(','),
+                inference_mode=False
+            )
 
-        hf_model = get_peft_model(base_model, peft_config)
+            hf_model = get_peft_model(base_model, peft_config)
+        else:
+            hf_model = base_model
+        
         model = cls(
-            lm_q=hf_model,
-            lm_p=hf_model,
-            pooler=None,
-            untie_encoder=False
+            encoder=hf_model,
+            pooling=model_args.pooling,
+            normalize=model_args.normalize
         )
         return model
     
@@ -110,12 +111,11 @@ class RepLLaMA(EncoderModel):
         hf_model = PeftModel.from_pretrained(base_model, model_name_or_path, config=config, is_trainable=True)
         hf_model = hf_model.merge_and_unload()
         model = cls(
-            lm_q=hf_model,
-            lm_p=hf_model,
-            pooler=None,
-            untie_encoder=False
+            encoder=hf_model,
+            pooling="cls",
+            normalize=False
         )
         return model
 
     def save(self, output_dir: str):
-        self.lm_q.save_pretrained(output_dir)
+        self.encoder.save_pretrained(output_dir)

--- a/examples/repllama/train.py
+++ b/examples/repllama/train.py
@@ -9,8 +9,9 @@ from transformers import (
     set_seed,
 )
 
-from tevatron.arguments import ModelArguments, DataArguments, \
+from tevatron.retriever.arguments import ModelArguments, DataArguments, \
     TevatronTrainingArguments as TrainingArguments
+
 from trainer import TevatronTrainer
 from data import HFTrainDataset, TrainDataset, TrainCollator
 from repllama import RepLLaMA
@@ -76,7 +77,7 @@ def main():
     )
 
     train_dataset = HFTrainDataset(tokenizer=tokenizer, data_args=data_args,
-                                   cache_dir=data_args.data_cache_dir or model_args.cache_dir)
+                                   cache_dir=data_args.dataset_cache_dir or model_args.cache_dir)
     if training_args.local_rank > 0:
         print("Waiting for main process to perform the mapping")
         torch.distributed.barrier()
@@ -92,8 +93,8 @@ def main():
         train_dataset=train_dataset,
         data_collator=TrainCollator(
             tokenizer,
-            max_p_len=data_args.p_max_len,
-            max_q_len=data_args.q_max_len
+            max_p_len=data_args.passage_max_len,
+            max_q_len=data_args.query_max_len,
         ),
     )
     train_dataset.trainer = trainer


### PR DESCRIPTION
Hi @MXueguang, 

I was running RepLLAMA on the `refactor` branch, but the RepLLAMA training and data scripts seem old. 
I have started this PR as a starting point.

I already started changing the old arguments and updating them wherever possible. 
Feel free to edit as there are places where there might be more changes required.

This fine-tuning code with RepLLAMA on the `refactor` branch:
```
export NCCL_P2P_DISABLE=1
export CACHE_DIR=<your_cache_dir>

deepspeed --include localhost:0,1,2 train.py \
  --deepspeed ds_config.json \
  --cache_dir $CACHE_DIR \
  --dataset_cache_dir $CACHE_DIR \
  --output_dir model_repllama \
  --model_name_or_path meta-llama/Llama-2-7b-hf \
  --save_steps 200 \
  --dataset_name Tevatron/msmarco-passage \
  --fp16 \
  --train_group_size 8 \
  --gradient_accumulation_steps 4 \
  --gradient_checkpointing \
  --pad_to_multiple_of 16 \
  --lora \
  --lora_target_modules "q_proj,v_proj,o_proj,down_proj,up_proj,gate_proj" \
  --learning_rate 1e-4 \
  --query_max_len 32 \
  --passage_max_len 196 \
  --num_train_epochs 1 \
  --logging_steps 10 \
  --overwrite_output_dir \
  --warmup_steps 100 \
  --dataset_number_of_shards 32
```