### PR TITLE
updated eval_beir.sh based on new scripts and arguments

### DIFF
--- a/scripts/eval_beir.sh
+++ b/scripts/eval_beir.sh
@@ -1,36 +1,95 @@
-ckpt=$1
-dataset=$2
-tokenizer=bert-base-uncased
-embedding_dir=beir_embedding_${ckpt}
+#!/bin/bash
 
-mkdir $embedding_dir
-for s in $(seq -f "%02g" 0 7)
-do
-CUDA_VISIBLE_DEVICES=0 python -m tevatron.driver.encode \
-  --output_dir=temp \
-  --model_name_or_path ${ckpt} \
-  --tokenizer_name ${tokenizer} \
-  --fp16 \
-  --per_device_eval_batch_size 64 \
-  --p_max_len 512 \
-  --dataset_name Tevatron/beir-corpus:${dataset} \
-  --encoded_save_path $embedding_dir/corpus_${dataset}.${s}.pkl \
-  --encode_num_shard 8 \
-  --encode_shard_index ${s}
+: '
+Example usage:
+./eval_beir.sh --lora_name_path /retriever-mistral/checkpoint-7600 \
+                    --dataset arguana \
+                    --tokenizer mistralai/Mistral-7B-v0.1 \
+                    --model_name_path mistralai/Mistral-7B-v0.1 \
+                    --embedding_dir beir_embedding_arguana \
+                    --query_prefix "Query: " \
+                    --passage_prefix "Passage: "
+ '
+
+# Default values
+lora_name_path=""
+dataset=""
+tokenizer=""
+model_name_path=""
+embedding_dir=""
+query_prefix="Query: "
+passage_prefix="Passage: "
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lora_name_path) lora_name_path="$2"; shift 2 ;;
+    --dataset) dataset="$2"; shift 2 ;;
+    --tokenizer) tokenizer="$2"; shift 2 ;;
+    --model_name_path) model_name_path="$2"; shift 2 ;;
+    --embedding_dir) embedding_dir="$2"; shift 2 ;;
+    --query_prefix) query_prefix="$2"; shift 2 ;;
+    --passage_prefix) passage_prefix="$2"; shift 2 ;;
+    --help) 
+      echo "Usage: $0 --lora_name_path <path> --dataset <dataset> --tokenizer <tokenizer> --model_name_path <model> --embedding_dir <directory> --query_prefix <prefix> --passage_prefix <prefix>"
+      exit 0 ;;
+    *) 
+      echo "Unknown argument: $1"; 
+      echo "Use --help to see the valid arguments."; 
+      exit 1 ;;
+  esac
 done
 
-CUDA_VISIBLE_DEVICES=0 python -m tevatron.driver.encode \
+# Check if required arguments are provided
+if [ -z "$lora_name_path" ] || [ -z "$dataset" ] || [ -z "$tokenizer" ] || [ -z "$model_name_path" ] || [ -z "$embedding_dir" ]; then
+  echo "Missing required arguments. Please provide all necessary options."
+  echo "Usage: $0 --lora_name_path <path> --dataset <dataset> --tokenizer <tokenizer> --model_name_path <model> --embedding_dir <directory> --query_prefix <prefix> --passage_prefix <prefix>"
+  exit 1
+fi
+
+# Create the embedding directory if it doesn't exist
+mkdir -p $embedding_dir
+
+# Encode passages
+for s in $(seq -f "%02g" 0 7); do
+  CUDA_VISIBLE_DEVICES=0 python -m tevatron.retriever.driver.encode \
+    --output_dir=temp \
+    --model_name_or_path ${model_name_path} \
+    --tokenizer_name ${tokenizer} \
+    --fp16 \
+    --lora \
+    --lora_name_or_path ${lora_name_path} \
+    --pooling eos \
+    --passage_prefix "${passage_prefix}" \
+    --per_device_eval_batch_size 64 \
+    --passage_max_len 156 \
+    --dataset_name Tevatron/beir-corpus \
+    --dataset_config ${dataset} \
+    --encode_output_path $embedding_dir/corpus_${dataset}.${s}.pkl \
+    --dataset_number_of_shards 8 \
+    --dataset_shard_index ${s}
+done
+
+# Encode queries
+CUDA_VISIBLE_DEVICES=0 python -m tevatron.retriever.driver.encode \
   --output_dir=temp \
-  --model_name_or_path ${ckpt} \
+  --model_name_or_path ${model_name_path} \
   --tokenizer_name ${tokenizer} \
   --fp16 \
+  --lora \
+  --lora_name_or_path ${lora_name_path} \
+  --pooling eos \
+  --query_prefix "${query_prefix}" \
   --per_device_eval_batch_size 64 \
-  --dataset_name Tevatron/beir:${dataset}/test \
-  --encoded_save_path $embedding_dir/query_${dataset}.pkl \
-  --q_max_len 512 \
-  --encode_is_qry
+  --dataset_name Tevatron/beir \
+  --dataset_config ${dataset} \
+  --dataset_split "test" \
+  --encode_output_path $embedding_dir/query_${dataset}.pkl \
+  --query_max_len 32 \
+  --encode_is_query
 
-set -f && OMP_NUM_THREADS=12 python -m tevatron.faiss_retriever \
+# Perform retrieval
+set -f && OMP_NUM_THREADS=12 python -m tevatron.retriever.driver.search \
     --query_reps $embedding_dir/query_${dataset}.pkl \
     --passage_reps $embedding_dir/corpus_${dataset}.*.pkl \
     --depth 1000 \
@@ -38,7 +97,11 @@ set -f && OMP_NUM_THREADS=12 python -m tevatron.faiss_retriever \
     --save_text \
     --save_ranking_to $embedding_dir/rank.${dataset}.txt
 
-python -m tevatron.utils.format.convert_result_to_trec --input $embedding_dir/rank.${dataset}.txt \
-                                                       --output $embedding_dir/rank.${dataset}.trec \
-                                                       --remove_query
+# Convert results to TREC format
+python -m tevatron.utils.format.convert_result_to_trec \
+    --input $embedding_dir/rank.${dataset}.txt \
+    --output $embedding_dir/rank.${dataset}.trec \
+    --remove_query
+
+# Evaluate results using pyserini
 python -m pyserini.eval.trec_eval -c -mrecall.100 -mndcg_cut.10 beir-v1.0.0-${dataset}-test $embedding_dir/rank.${dataset}.trec

--- a/scripts/eval_beir.sh
+++ b/scripts/eval_beir.sh
@@ -8,8 +8,9 @@ Example usage:
                     --embedding_dir beir_embedding_arguana \
                     --query_prefix "Query: " \
                     --passage_prefix "Passage: " \
-                    [--lora_name_path /retriever-mistral/checkpoint-7600]
- '
+                    [--lora_name_path /retriever-mistral/checkpoint-7600] \
+                    [--normalize]
+'
 
 # Default values
 lora_name_path=""
@@ -19,6 +20,7 @@ model_name_path=""
 embedding_dir=""
 query_prefix="Query: "
 passage_prefix="Passage: "
+normalize_flag=""
 
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -30,8 +32,9 @@ while [[ $# -gt 0 ]]; do
     --embedding_dir) embedding_dir="$2"; shift 2 ;;
     --query_prefix) query_prefix="$2"; shift 2 ;;
     --passage_prefix) passage_prefix="$2"; shift 2 ;;
+    --normalize) normalize_flag="--normalize"; shift ;;
     --help) 
-      echo "Usage: $0 --dataset <dataset> --tokenizer <tokenizer> --model_name_path <model> --embedding_dir <directory> --query_prefix <prefix> --passage_prefix <prefix> [--lora_name_path <path>]"
+      echo "Usage: $0 --dataset <dataset> --tokenizer <tokenizer> --model_name_path <model> --embedding_dir <directory> --query_prefix <prefix> --passage_prefix <prefix> [--lora_name_path <path>] [--normalize]"
       exit 0 ;;
     *) 
       echo "Unknown argument: $1"; 
@@ -43,7 +46,7 @@ done
 # Check if required arguments are provided
 if [ -z "$dataset" ] || [ -z "$tokenizer" ] || [ -z "$model_name_path" ] || [ -z "$embedding_dir" ]; then
   echo "Missing required arguments. Please provide all necessary options."
-  echo "Usage: $0 --dataset <dataset> --tokenizer <tokenizer> --model_name_path <model> --embedding_dir <directory> --query_prefix <prefix> --passage_prefix <prefix> [--lora_name_path <path>]"
+  echo "Usage: $0 --dataset <dataset> --tokenizer <tokenizer> --model_name_path <model> --embedding_dir <directory> --query_prefix <prefix> --passage_prefix <prefix> [--lora_name_path <path>] [--normalize]"
   exit 1
 fi
 
@@ -64,6 +67,7 @@ for s in $(seq -f "%02g" 0 7); do
     --tokenizer_name ${tokenizer} \
     --fp16 \
     ${lora_args} \
+    ${normalize_flag} \
     --pooling eos \
     --passage_prefix "${passage_prefix}" \
     --per_device_eval_batch_size 64 \
@@ -82,6 +86,7 @@ CUDA_VISIBLE_DEVICES=0 python -m tevatron.retriever.driver.encode \
   --tokenizer_name ${tokenizer} \
   --fp16 \
   ${lora_args} \
+  ${normalize_flag} \
   --pooling eos \
   --query_prefix "${query_prefix}" \
   --per_device_eval_batch_size 64 \


### PR DESCRIPTION
Previous shell script for evaluation of beir is copy and paste of tevatron 1.0. It does not work because:
1. the scripts are changed in the main branch
2. the arguments names are changed too

Updated script works with the main branch script for evaluation as it is.

Current example usage of the updated script:
```
./eval_beir.sh --lora_name_path /retriever-mistral/checkpoint-7600 \
                    --dataset arguana \
                    --tokenizer mistralai/Mistral-7B-v0.1 \
                    --model_name_path mistralai/Mistral-7B-v0.1 \
                    --embedding_dir beir_embedding_arguana \
                    --query_prefix "Query: " \
                    --passage_prefix "Passage: "
```