### PR TITLE
Splade Encoding and Evaluation not working

### DIFF
--- a/examples/splade/README.md
+++ b/examples/splade/README.md
@@ -32,6 +32,7 @@ python encode_splade.py \
   --model_name_or_path model_msmarco_splade \
   --tokenizer_name bert-base-uncased \
   --fp16 \
+  --passage_max_len 128 \
   --per_device_eval_batch_size 512 \
   --dataset_name Tevatron/msmarco-passage-corpus \
   --dataset_number_of_shards 10 \
@@ -39,7 +40,7 @@ python encode_splade.py \
   --encode_output_path encoding_splade/corpus/split${i}.jsonl
 done
 
-python -m encode_splade.py \
+python encode_splade.py \
   --output_dir encoding_splade \
   --model_name_or_path model_msmarco_splade \
   --tokenizer_name bert-base-uncased \
@@ -48,7 +49,7 @@ python -m encode_splade.py \
   --encode_is_query \
   --per_device_eval_batch_size 128 \
   --dataset_name Tevatron/msmarco-passage/dev \
-  --encoded_output_path encoding_splade/query/dev.tsv
+  --encode_output_path encoding_splade/query/dev.tsv
 ```
 
 ## Index SPLADE with anserini

--- a/examples/splade/README.md
+++ b/examples/splade/README.md
@@ -34,9 +34,9 @@ python encode_splade.py \
   --fp16 \
   --per_device_eval_batch_size 512 \
   --dataset_name Tevatron/msmarco-passage-corpus \
-  --encode_num_shard 10 \
-  --encode_shard_index ${i} \
-  --encoded_save_path encoding_splade/corpus/split${i}.jsonl
+  --dataset_number_of_shards 10 \
+  --dataset_shard_index ${i} \
+  --encode_output_path encoding_splade/corpus/split${i}.jsonl
 done
 
 python -m encode_splade.py \
@@ -44,11 +44,11 @@ python -m encode_splade.py \
   --model_name_or_path model_msmarco_splade \
   --tokenizer_name bert-base-uncased \
   --fp16 \
-  --q_max_len 128 \
-  --encode_is_qry \
+  --query_max_len 128 \
+  --encode_is_query \
   --per_device_eval_batch_size 128 \
   --dataset_name Tevatron/msmarco-passage/dev \
-  --encoded_save_path encoding_splade/query/dev.tsv
+  --encoded_output_path encoding_splade/query/dev.tsv
 ```
 
 ## Index SPLADE with anserini


### PR DESCRIPTION
Hi @MXueguang ,
Based on your suggestion from https://github.com/texttron/tevatron/issues/149 to use [splade example](https://github.com/texttron/tevatron/tree/main/examples/splade).

It has few issues:

- [x] 1. [encode_splade.py](https://github.com/texttron/tevatron/blob/main/examples/splade/encode_splade.py) is outdated based on new arguments and module paths in the latest library updates.
- [x] 2. Readme instruction for encoding is outdated, for passing right argument names.
- [ ] 3. Need to verify if the evaluation scripts works and replicate the evaluation result on atleast one splade version.

I have fixed the first two already in the current pull request. To work on the last, I just want to check if we should create a function in [searcher python file](https://github.com/texttron/tevatron/blob/main/src/tevatron/retriever/searcher.py) for sparse retriever output (It might be more consistent with the repo?), or keep the original index->retrieve->evaluate using pyserini from readme instruction. Please share your thoughts.

Thanks,
Srikanth 