### PR TITLE
Add pyserini related info to readme

### DIFF
--- a/examples/example_repllama.md
+++ b/examples/example_repllama.md
@@ -70,7 +70,13 @@ python -m tevatron.utils.format.convert_result_to_trec --input beir_embedding_sc
                                                        --remove_query
 ```
 
-### Evaluate
+### Evaluate 
+Install Pyserini 
+```bash
+`pip install pyserini`
+```
+> [!NOTE]  
+> The [psyserini](https://github.com/castorini/pyserini/tree/master) library as of v0.44.0 is using features that are no longer supported for python version >3.10; hence, configure your environment to use python3.10
 ```bash
 python -m pyserini.eval.trec_eval -c -mrecall.100 -mndcg_cut.10 beir-v1.0.0-scifact-test beir_embedding_scifact/rank.scifact.trec
 

--- a/examples/example_repllama_vllm.md
+++ b/examples/example_repllama_vllm.md
@@ -89,6 +89,13 @@ python -m tevatron.utils.format.convert_result_to_trec --input beir_embedding_sc
 ```
 
 ### Evaluate
+Install Pyserini 
+```bash
+`pip install pyserini`
+```
+> [!NOTE]  
+> The [psyserini](https://github.com/castorini/pyserini/tree/master) library as of v0.44.0 is using features that are no longer supported for python version >3.10; hence, configure your environment to use python3.10
+
 ```bash
 python -m pyserini.eval.trec_eval -c -mrecall.100 -mndcg_cut.10 beir-v1.0.0-scifact-test beir_embedding_scifact/rank.scifact.trec
 


### PR DESCRIPTION
While reproducing the results outlined in the README, I found some gaps in the documentation that could lead to issues during setup and evaluation:
- missing instruction to install the pyserini library prior to evaluation
- added python version compatibility warning: I encountered hidden errors caused by the pyserini library not supporting Python versions greater than 3.10 