### PR TITLE
Reranker adaptations (nanochat/causal-LM rerankers)

### DIFF
--- a/src/tevatron/reranker/arguments.py
+++ b/src/tevatron/reranker/arguments.py
@@ -17,6 +17,21 @@ class ModelArguments:
         default=None, metadata={"help": "Where do you want to store the pretrained models downloaded from s3"}
     )
 
+    reranker_model_type: str = field(
+        default="sequence_classification",
+        metadata={"help": "Reranker model type: sequence_classification or backbone"}
+    )
+
+    reranker_pooling: str = field(
+        default="last",
+        metadata={"help": "Pooling method for backbone rerankers: last or cls"}
+    )
+
+    attn_implementation: Optional[str] = field(
+        default=None,
+        metadata={"help": "Attention implementation to pass to from_pretrained, e.g. sdpa or flash_attention_2"}
+    )
+
     # for lora
     lora: bool = field(default=False,
         metadata={"help": "do parameter-efficient fine-tuning with lora"}
@@ -98,11 +113,11 @@ class DataArguments:
     )
 
     query_prefix: str = field(
-        default='query:', metadata={"help": "prefix or instruction for query"}
+        default='', metadata={"help": "prefix or instruction for query"}
     )
 
     passage_prefix: str = field(
-        default='passage:', metadata={"help": "prefix or instruction for passage"}
+        default='', metadata={"help": "prefix or instruction for passage"}
     )
 
     append_eos_token: bool = field(

--- a/src/tevatron/reranker/modeling.py
+++ b/src/tevatron/reranker/modeling.py
@@ -1,10 +1,11 @@
 import os
+import json
 from dataclasses import dataclass
 from typing import Dict, Optional
 
 import torch
 from torch import nn, Tensor
-from transformers import AutoModelForSequenceClassification, PreTrainedModel
+from transformers import AutoModel, AutoModelForSequenceClassification, PreTrainedModel
 from transformers.file_utils import ModelOutput
 from transformers import TrainingArguments
 from tevatron.reranker.arguments import ModelArguments
@@ -21,12 +22,22 @@ class RerankerOutput(ModelOutput):
 
 class RerankerModel(nn.Module):
     TRANSFORMER_CLS = AutoModelForSequenceClassification
+    BACKBONE_CLS = AutoModel
+    RERANKER_CONFIG = "reranker_config.json"
+    RERANKER_HEAD = "reranker_head.pt"
 
-    def __init__(self, hf_model: PreTrainedModel, train_batch_size: int = None):
+    def __init__(self, hf_model: PreTrainedModel, train_batch_size: int = None,
+                 reranker_model_type: str = "sequence_classification",
+                 reranker_pooling: str = "last"):
         super().__init__()
         self.config = hf_model.config
         self.hf_model = hf_model
         self.train_batch_size = train_batch_size
+        self.reranker_model_type = reranker_model_type
+        self.reranker_pooling = reranker_pooling
+        if self.reranker_model_type == "backbone":
+            self.score = nn.Linear(self.hf_model.config.hidden_size, 1, bias=False)
+            self.score.to(dtype=next(self.hf_model.parameters()).dtype)
         self.cross_entropy = nn.CrossEntropyLoss(reduction='mean')
         if train_batch_size:
             self.register_buffer(
@@ -41,7 +52,11 @@ class RerankerModel(nn.Module):
                 logger.warning('{} data: {}'.format(name, param.data.cpu().numpy()))
 
     def forward(self, pair: Dict[str, Tensor] = None):
-        ranker_logits = self.hf_model(**pair, return_dict=True).logits
+        if self.reranker_model_type == "backbone":
+            outputs = self.hf_model(**pair, return_dict=True)
+            ranker_logits = self.score(self._pool_sequence(outputs.last_hidden_state, pair))
+        else:
+            ranker_logits = self.hf_model(**pair, return_dict=True).logits
         if self.train_batch_size:
             grouped_logits = ranker_logits.view(self.train_batch_size, -1)
             loss = self.cross_entropy(grouped_logits, self.target_label)
@@ -54,9 +69,24 @@ class RerankerModel(nn.Module):
             loss = None,
             scores = ranker_logits
         )
-    
+
+    def _pool_sequence(self, last_hidden_state: Tensor, pair: Dict[str, Tensor]):
+        if self.reranker_pooling == "cls":
+            return last_hidden_state[:, 0]
+        if self.reranker_pooling != "last":
+            raise ValueError(f"Unsupported reranker_pooling: {self.reranker_pooling}")
+
+        if "attention_mask" not in pair:
+            return last_hidden_state[:, -1]
+        sequence_lengths = pair["attention_mask"].long().sum(dim=1) - 1
+        batch_idx = torch.arange(last_hidden_state.size(0), device=last_hidden_state.device)
+        return last_hidden_state[batch_idx, sequence_lengths]
+
     def gradient_checkpointing_enable(self, **kwargs):
-        self.hf_model.gradient_checkpointing_enable(**kwargs)
+        if hasattr(self.hf_model, "gradient_checkpointing_enable"):
+            self.hf_model.gradient_checkpointing_enable(**kwargs)
+        else:
+            self.hf_model.base_model.model.gradient_checkpointing_enable(**kwargs)
 
     @classmethod
     def build(
@@ -65,11 +95,17 @@ class RerankerModel(nn.Module):
             train_args: TrainingArguments,
             **hf_kwargs,
     ):
-        base_model = cls.TRANSFORMER_CLS.from_pretrained(
-            model_args.model_name_or_path,
-            num_labels=1,
-            **hf_kwargs,
-        )
+        if model_args.attn_implementation:
+            hf_kwargs["attn_implementation"] = model_args.attn_implementation
+
+        if model_args.reranker_model_type == "backbone":
+            base_model = cls.BACKBONE_CLS.from_pretrained(model_args.model_name_or_path, **hf_kwargs)
+        else:
+            base_model = cls.TRANSFORMER_CLS.from_pretrained(
+                model_args.model_name_or_path,
+                num_labels=1,
+                **hf_kwargs,
+            )
         if base_model.config.pad_token_id is None:
             base_model.config.pad_token_id = 0
         if model_args.lora or model_args.lora_name_or_path:
@@ -78,11 +114,11 @@ class RerankerModel(nn.Module):
                 base_model.enable_input_require_grads()
             if model_args.lora_name_or_path:
                 lora_config = LoraConfig.from_pretrained(model_args.lora_name_or_path, **hf_kwargs)
-                lora_model = PeftModel.from_pretrained(base_model, model_args.lora_name_or_path, torch_dtype=torch.bfloat16, attn_implementation="flash_attention_2")
+                lora_model = PeftModel.from_pretrained(base_model, model_args.lora_name_or_path, is_trainable=True)
             else:
                 lora_config = LoraConfig(
                     base_model_name_or_path=model_args.model_name_or_path,
-                    task_type=TaskType.SEQ_CLS,
+                    task_type=TaskType.FEATURE_EXTRACTION if model_args.reranker_model_type == "backbone" else TaskType.SEQ_CLS,
                     r=model_args.lora_r,
                     lora_alpha=model_args.lora_alpha,
                     lora_dropout=model_args.lora_dropout,
@@ -93,11 +129,15 @@ class RerankerModel(nn.Module):
             model = cls(
                 hf_model=lora_model,
                 train_batch_size=train_args.per_device_train_batch_size,
+                reranker_model_type=model_args.reranker_model_type,
+                reranker_pooling=model_args.reranker_pooling,
             )
         else:
             model = cls(
                 hf_model=base_model,
                 train_batch_size=train_args.per_device_train_batch_size,
+                reranker_model_type=model_args.reranker_model_type,
+                reranker_pooling=model_args.reranker_pooling,
             )
         return model
 
@@ -106,10 +146,32 @@ class RerankerModel(nn.Module):
              model_name_or_path: str,
              lora_name_or_path: str = None,
              **hf_kwargs):
-        base_model = cls.TRANSFORMER_CLS.from_pretrained(model_name_or_path, num_labels=1, **hf_kwargs, torch_dtype=torch.bfloat16, attn_implementation="flash_attention_2")
+        reranker_config = cls._load_reranker_config(model_name_or_path)
+        reranker_model_type = reranker_config.get("reranker_model_type", "sequence_classification")
+        reranker_pooling = reranker_config.get("reranker_pooling", "last")
+        if reranker_config.get("attn_implementation"):
+            hf_kwargs["attn_implementation"] = reranker_config["attn_implementation"]
+
+        if reranker_model_type == "backbone":
+            from peft import PeftConfig, PeftModel
+            adapter_path = lora_name_or_path
+            base_model_name_or_path = model_name_or_path
+            if adapter_path is None and os.path.exists(os.path.join(model_name_or_path, "adapter_config.json")):
+                adapter_path = model_name_or_path
+                base_model_name_or_path = PeftConfig.from_pretrained(adapter_path).base_model_name_or_path
+            base_model = cls.BACKBONE_CLS.from_pretrained(base_model_name_or_path, **hf_kwargs)
+        else:
+            base_model = cls.TRANSFORMER_CLS.from_pretrained(model_name_or_path, num_labels=1, **hf_kwargs, torch_dtype=torch.bfloat16, attn_implementation="flash_attention_2")
         if base_model.config.pad_token_id is None:
             base_model.config.pad_token_id = 0
-        if lora_name_or_path:
+        if reranker_model_type == "backbone" and adapter_path:
+            lora_model = PeftModel.from_pretrained(base_model, adapter_path)
+            model = cls(
+                hf_model=lora_model,
+                reranker_model_type=reranker_model_type,
+                reranker_pooling=reranker_pooling,
+            )
+        elif reranker_model_type != "backbone" and lora_name_or_path:
             from peft import LoraConfig, PeftModel
             lora_config = LoraConfig.from_pretrained(lora_name_or_path, **hf_kwargs)
             lora_model = PeftModel.from_pretrained(base_model, lora_name_or_path, config=lora_config)
@@ -120,12 +182,61 @@ class RerankerModel(nn.Module):
         else:
             model = cls(
                 hf_model=base_model,
+                reranker_model_type=reranker_model_type,
+                reranker_pooling=reranker_pooling,
             )
+        if reranker_model_type == "backbone":
+            model._load_score_head(model_name_or_path)
         return model
 
-    def save(self, output_dir: str, state_dict=None):
+    def save(self, output_dir: str, state_dict: Dict[str, Tensor] = None):
         # Under FSDP full_shard, the Trainer gathers a consolidated full-rank
         # state_dict and hands it in; pass it through so save_pretrained writes
-        # the real weights instead of this rank's shard. state_dict keys here
-        # are already de-prefixed (hf_model. stripped by the caller).
-        self.hf_model.save_pretrained(output_dir, state_dict=state_dict)
+        # the real weights instead of this rank's shard. Plain DDP -> state_dict
+        # is None and save_pretrained pulls from the (replicated) model directly.
+        # The trainer keeps any "score." keys out of what it strips/passes here
+        # as hf_model weights, so they're carved out separately below.
+        if state_dict is not None:
+            hf_state_dict = {k: v for k, v in state_dict.items() if not k.startswith("score.")}
+        else:
+            hf_state_dict = None
+        self.hf_model.save_pretrained(output_dir, state_dict=hf_state_dict)
+        self._save_reranker_extras(output_dir, state_dict=state_dict)
+
+    def _save_reranker_extras(self, output_dir: str, state_dict: Dict[str, Tensor] = None):
+        """Writes reranker_config.json and (for backbone rerankers) the score head.
+
+        Shared by the full-FT save path above and the trainer's LoRA-adapter save
+        path, which saves only the adapter via `get_peft_model_state_dict` and
+        needs this called separately for the score head to be persisted too.
+        """
+        with open(os.path.join(output_dir, self.RERANKER_CONFIG), "w") as f:
+            json.dump({
+                "reranker_model_type": self.reranker_model_type,
+                "reranker_pooling": self.reranker_pooling,
+                "attn_implementation": getattr(self.hf_model.config, "_attn_implementation", None),
+            }, f, indent=2)
+        if self.reranker_model_type == "backbone":
+            if state_dict is not None:
+                score_state_dict = {
+                    k[len("score."):]: v.cpu()
+                    for k, v in state_dict.items()
+                    if k.startswith("score.")
+                }
+            else:
+                score_state_dict = {k: v.cpu() for k, v in self.score.state_dict().items()}
+            torch.save(score_state_dict, os.path.join(output_dir, self.RERANKER_HEAD))
+
+    @classmethod
+    def _load_reranker_config(cls, model_name_or_path: str):
+        config_path = os.path.join(model_name_or_path, cls.RERANKER_CONFIG)
+        if not os.path.exists(config_path):
+            return {}
+        with open(config_path) as f:
+            return json.load(f)
+
+    def _load_score_head(self, model_name_or_path: str):
+        head_path = os.path.join(model_name_or_path, self.RERANKER_HEAD)
+        if not os.path.exists(head_path):
+            raise FileNotFoundError(f"Backbone reranker checkpoint is missing {self.RERANKER_HEAD}: {model_name_or_path}")
+        self.score.load_state_dict(torch.load(head_path, map_location="cpu"))

--- a/src/tevatron/reranker/trainer.py
+++ b/src/tevatron/reranker/trainer.py
@@ -18,13 +18,22 @@ def _is_deepspeed_zero3_enabled():
 
 
 def _strip_hf_model_prefix(state_dict):
-    """Drop the 'hf_model.' wrapper prefix so keys match the bare HF model."""
+    """Drop the 'hf_model.' wrapper prefix so keys match the bare HF model.
+
+    Backbone rerankers additionally carry a sibling 'score.' head (not part of
+    hf_model) — those keys are passed through unstripped so callers can split
+    them out for RerankerModel._save_reranker_extras.
+    """
     prefix = 'hf_model.'
     assert all(
-        k.startswith(prefix) or k == "target_label"
+        k.startswith(prefix) or k.startswith('score.') or k == "target_label"
         for k in state_dict.keys()
     ), list(state_dict.keys())
-    return {k[len(prefix):]: v for k, v in state_dict.items() if k.startswith(prefix)}
+    return {
+        (k[len(prefix):] if k.startswith(prefix) else k): v
+        for k, v in state_dict.items()
+        if k.startswith(prefix) or k.startswith('score.')
+    }
 
 
 class RerankerTrainer(Trainer):
@@ -48,15 +57,21 @@ class RerankerTrainer(Trainer):
 
         if is_lora:
             # Adapter-only save: de-prefix the (gathered) state_dict and let PEFT
-            # extract the adapter weights.
+            # extract the adapter weights. Backbone rerankers also carry a
+            # 'score.' head sibling to hf_model, which PEFT doesn't know about —
+            # split it out and save it (+ reranker_config.json) separately.
             from peft import get_peft_model_state_dict
             if state_dict is None:
                 state_dict = self.model.state_dict()
             state_dict = _strip_hf_model_prefix(state_dict)
-            lora_state_dict = get_peft_model_state_dict(self.model.hf_model, state_dict)
+            score_state_dict = {k: v for k, v in state_dict.items() if k.startswith('score.')}
+            hf_state_dict = {k: v for k, v in state_dict.items() if not k.startswith('score.')}
+            lora_state_dict = get_peft_model_state_dict(self.model.hf_model, hf_state_dict)
             if self.args.process_index <= 0:
                 torch.save(lora_state_dict, os.path.join(output_dir, "adapter_model.bin"))
                 print(f"Save adapter model at {output_dir}")
+                if getattr(self.model, "reranker_model_type", None) == "backbone":
+                    self.model._save_reranker_extras(output_dir, state_dict=score_state_dict)
             return
 
         # Full-FT save. Under FSDP full_shard the Trainer hands in a gathered


### PR DESCRIPTION
## Summary

  Adds support for using a causal-LM/decoder backbone (e.g. nanochat) as a reranker, alongside the existing
  `AutoModelForSequenceClassification` cross-encoder path. Fully backward compatible — `reranker_model_type` defaults
  to `sequence_classification`, so existing checkpoints and training runs are unaffected.
  
  ## Motivation
  
  Some backbones (e.g. nanochat) don't ship a sequence-classification head, and we want to fine-tune them as
  rerankers directly on top of their causal-LM representations rather than requiring a separate
  classification-head-compatible checkpoint.
  
  ## Changes
  
  - **New `backbone` reranker mode** (`reranker_model_type=backbone`): loads the model via `AutoModel` instead of
  `AutoModelForSequenceClassification`, and scores pairs through a separately-trained linear head on top of pooled
  hidden states.
  - **Configurable pooling** for backbone mode (`reranker_pooling=last|cls`) — `last` needed because causal-LM
  backbones don't have a natural `[CLS]` token position and left/right padding varies by tokenizer.
  - **LoRA task type switched to `FEATURE_EXTRACTION`** for backbone mode (vs `SEQ_CLS` for sequence_classification) 
  — required because backbone mode has no classification head for PEFT to wrap.
  - **New checkpoint sidecar files** — `reranker_config.json` (records model type/pooling/attn implementation) and 
  `reranker_head.pt` (score head weights) are written next to the HF checkpoint so backbone reranker checkpoints can 
  be reloaded without external config. Sequence_classification checkpoints are unaffected (no sidecar files 
  written/expected).
  - **Score head now survives adapter-only saves** — previously, LoRA/adapter-only checkpointing (used under
  DeepSpeed ZeRO-3 / FSDP) would silently drop any weights outside the `hf_model.` namespace. The score head is now
  split out and persisted alongside the adapter in that path too, not just on full fine-tune saves.
  - **`query_prefix`/`passage_prefix` defaults changed from `'query:'`/`'passage:'` to `''`** — the old literal
  prefix isn't meaningful for backbones (like nanochat) that weren't trained with it. This affects both reranker
  modes; existing runs relying on the old default should now pass the prefix explicitly.
  - **`gradient_checkpointing_enable` made more defensive** — falls back only when the wrapped model lacks its own
  `gradient_checkpointing_enable`, since backbone+LoRA wraps the base model differently than
  sequence_classification+LoRA.
  
  ## Compatibility
  
  - Existing `sequence_classification` checkpoints load and train exactly as before.
  - New backbone-mode checkpoints require `reranker_config.json` + `reranker_head.pt` to be present at load time;
  missing `reranker_head.pt` raises `FileNotFoundError` rather than silently loading random weights.